### PR TITLE
Latests changes from the twisted/master branch

### DIFF
--- a/docs/source/NEWS.rst
+++ b/docs/source/NEWS.rst
@@ -19,6 +19,8 @@ Changes
 
 - Using modern classmethod decorator instead of old-style method call.
 - Usage of zope.interfaces was updated in preparation for python3 port.
+- ``toWire`` method is used to get bytes representation of ``ldaptor.protocols.pureber`` and
+  ``ldaptor.protocols.pureldap`` classes instead of ``__str__`` which is deprecated now.
 - Code was updated to pass `python3 -m compileall` in preparation for py3 port.
 - Continuous test are executed only against latest related Twisted and latest
   Twisted trunk branch.

--- a/docs/source/NEWS.rst
+++ b/docs/source/NEWS.rst
@@ -34,7 +34,7 @@ Bugfixes
 
 - DN matching is now case insensitive.
 - Proxies now terminate the connection to the proxied server in case a client immediately closes the connection.
-
+- asText() implemented for LDAPFilter_extensibleMatch
 
 Release 16.0 (2016-06-07)
 -------------------------

--- a/ldaptor/delta.py
+++ b/ldaptor/delta.py
@@ -32,12 +32,12 @@ class Modification(attributeset.LDAPAttributeSet):
                 value = tmplist[x]
                 newlist.append(value) 
         
-        return str(pureber.BERSequence([
+        return pureber.BERSequence([
             pureber.BEREnumerated(self._LDAP_OP),
             pureber.BERSequence([ pureldap.LDAPAttributeDescription(self.key),
                                   pureber.BERSet(map(pureldap.LDAPString, newlist)),
                                   ]),
-            ]))
+            ]).toWire()
 
     def __eq__(self, other):
         if not isinstance(other, self.__class__):

--- a/ldaptor/encoder.py
+++ b/ldaptor/encoder.py
@@ -1,0 +1,13 @@
+"""
+    Encoding / decoding utilities
+"""
+
+import six
+
+
+def to_bytes(value):
+    if hasattr(value, 'toWire'):
+        return value.toWire()
+    if isinstance(value, six.text_type):
+        return value.encode('utf-8')
+    return bytes(value)

--- a/ldaptor/protocols/pureldap.py
+++ b/ldaptor/protocols/pureldap.py
@@ -683,7 +683,7 @@ class LDAPMatchingRuleAssertion(BERSequence):
 
         return r
 
-    def __init__(self, matchingRule=None, type=None, matchValue=None, dnAttributes=None, tag=None):
+    def __init__(self, matchingRule=None, type=None, matchValue=None, dnAttributes=None, tag=None, escaper=escape):
         BERSequence.__init__(self, value=[], tag=tag)
         assert matchValue is not None
         if isinstance(matchingRule, six.string_types):
@@ -704,6 +704,7 @@ class LDAPMatchingRuleAssertion(BERSequence):
         self.dnAttributes = dnAttributes
         if not self.dnAttributes:
             self.dnAttributes = None
+        self.escaper = escaper
 
     def __str__(self):
         return str(BERSequence(
@@ -723,8 +724,15 @@ class LDAPMatchingRuleAssertion(BERSequence):
 
 class LDAPFilter_extensibleMatch(LDAPMatchingRuleAssertion):
     tag = CLASS_CONTEXT | 0x09
-    pass
 
+    def asText(self):
+        return '(' + \
+               (self.type.value if self.type else '') + \
+               (':dn' if self.dnAttributes.value else '') + \
+               ((':' + self.matchingRule.value) if self.matchingRule else '') + \
+               ':=' + \
+               self.escaper(self.matchValue.value) + \
+               ')'
 
 class LDAPBERDecoderContext_Filter(BERDecoderContext):
     Identities = {

--- a/ldaptor/test/test_encoder.py
+++ b/ldaptor/test/test_encoder.py
@@ -1,0 +1,29 @@
+"""
+    Test cases for ldaptor.encoder module
+"""
+
+from twisted.trial import unittest
+
+import six
+
+from ldaptor.encoder import to_bytes
+
+
+class WireableObject(object):
+    def toWire(self):
+        return b'wire'
+
+
+class EncoderTests(unittest.TestCase):
+
+    def test_wireable_object(self):
+        obj = WireableObject()
+        self.assertEqual(to_bytes(obj), b'wire')
+
+    def test_unicode_object(self):
+        obj = six.u('unicode')
+        self.assertEqual(to_bytes(obj), b'unicode')
+
+    def test_bytes_object(self):
+        obj = b'bytes'
+        self.assertEqual(to_bytes(obj), b'bytes')

--- a/ldaptor/test/test_ldapfilter.py
+++ b/ldaptor/test/test_ldapfilter.py
@@ -57,43 +57,47 @@ class RFC2254Examples(unittest.TestCase):
 
     def test_extensible_1(self):
         text = '(cn:1.2.3.4.5:=Fred Flintstone)'
-        self.assertEqual(ldapfilter.parseFilter(text),
-                          pureldap.LDAPFilter_extensibleMatch(
+        filt = pureldap.LDAPFilter_extensibleMatch(
             type='cn',
             dnAttributes=False,
             matchingRule='1.2.3.4.5',
             matchValue='Fred Flintstone',
-            ))
+            )
+        self.assertEqual(ldapfilter.parseFilter(text), filt)
+        self.assertEqual(filt.asText(), text)
 
     def test_extensible_2(self):
         text = '(sn:dn:2.4.6.8.10:=Barney Rubble)'
-        self.assertEqual(ldapfilter.parseFilter(text),
-                          pureldap.LDAPFilter_extensibleMatch(
+        filt = pureldap.LDAPFilter_extensibleMatch(
             type='sn',
             dnAttributes=True,
             matchingRule='2.4.6.8.10',
             matchValue='Barney Rubble',
-            ))
+            )
+        self.assertEqual(ldapfilter.parseFilter(text), filt)
+        self.assertEqual(filt.asText(), text)
 
     def test_extensible_3(self):
         text = '(o:dn:=Ace Industry)'
-        self.assertEqual(ldapfilter.parseFilter(text),
-                          pureldap.LDAPFilter_extensibleMatch(
+        filt = pureldap.LDAPFilter_extensibleMatch(
             type='o',
             dnAttributes=True,
             matchingRule=None,
             matchValue='Ace Industry',
-            ))
+            )
+        self.assertEqual(ldapfilter.parseFilter(text), filt)
+        self.assertEqual(filt.asText(), text)
 
     def test_extensible_4(self):
         text = '(:dn:2.4.6.8.10:=Dino)'
-        self.assertEqual(ldapfilter.parseFilter(text),
-                          pureldap.LDAPFilter_extensibleMatch(
+        filt = pureldap.LDAPFilter_extensibleMatch(
             type=None,
             dnAttributes=True,
             matchingRule='2.4.6.8.10',
             matchValue='Dino',
-            ))
+            )
+        self.assertEqual(ldapfilter.parseFilter(text), filt)
+        self.assertEqual(filt.asText(), text)
 
     def test_escape_parens(self):
         text = r'(o=Parens R Us \28for all your parenthetical needs\29)'

--- a/ldaptor/test/test_pureldap.py
+++ b/ldaptor/test/test_pureldap.py
@@ -23,17 +23,17 @@ from ldaptor.protocols import pureldap, pureber
 
 
 def s(*l):
-    """Join all members of list to a string. Integer members are chr()ed"""
-    r=''
+    """Join all members of list to a byte string. Integer members are chr()ed"""
+    r = b''
     for e in l:
         if isinstance(e, int):
-            e = chr(e)
-        r = r + str(e)
+            e = six.int2byte(e)
+        r = r + e
     return r
 
 
 def l(s):
-    """Split a string to ord's of chars."""
+    """Split a byte string to ord's of chars."""
     return [six.byte2int([x]) for x in s]
 
 
@@ -58,15 +58,15 @@ class KnownValues(unittest.TestCase):
            },
          None,
          [0x66, 50]
-         + ([0x04, 0x1a] + l("cn=foo, dc=example, dc=com")
+         + ([0x04, 0x1a] + l(b"cn=foo, dc=example, dc=com")
             + [0x30, 20]
             + ([0x30, 18]
                + ([0x0a, 0x01, 0x00]
                   + [0x30, 13]
-                  + ([0x04, len("bar")] + l("bar")
+                  + ([0x04, len(b"bar")] + l(b"bar")
                      + [0x31, 0x06]
-                     + ([0x04, len("a")] + l("a")
-                        + [0x04, len("b")] + l("b"))))))
+                     + ([0x04, len(b"a")] + l(b"a")
+                        + [0x04, len(b"b")] + l(b"b"))))))
             ),
 
         (pureldap.LDAPModifyRequest,
@@ -84,12 +84,12 @@ class KnownValues(unittest.TestCase):
            },
          None,
          [0x66, 0x2c]
-         + ([0x04, 0x1a] + l("cn=foo, dc=example, dc=com")
+         + ([0x04, 0x1a] + l(b"cn=foo, dc=example, dc=com")
             + [0x30, 0x0e]
             + ([0x30, 0x0c]
                + ([0x0a, 0x01, 0x01]
                   + [0x30, 0x07]
-                  + ([0x04, 0x03] + l("bar")
+                  + ([0x04, 0x03] + l(b"bar")
                      + [0x31, 0x00]))))
         ),
 
@@ -100,8 +100,8 @@ class KnownValues(unittest.TestCase):
          pureldap.LDAPBERDecoderContext_Filter(fallback=pureber.BERDecoderContext()),
          [0xa2, 0x05]
          + [0x87]
-         + [len("foo")]
-         + l("foo")),
+         + [len(b"foo")]
+         + l(b"foo")),
 
         (pureldap.LDAPFilter_or,
          [],
@@ -116,11 +116,11 @@ class KnownValues(unittest.TestCase):
          pureldap.LDAPBERDecoderContext_Filter(fallback=pureber.BERDecoderContext()),
          [0xa1, 23]
          + [0xa3, 9]
-         + [0x04] + [len("cn")] + l("cn")
-         + [0x04] + [len("foo")] + l("foo")
+         + [0x04] + [len(b"cn")] + l(b"cn")
+         + [0x04] + [len(b"foo")] + l(b"foo")
          + [0xa3, 10]
-         + [0x04] + [len("uid")] + l("uid")
-         + [0x04] + [len("foo")] + l("foo"),
+         + [0x04] + [len(b"uid")] + l(b"uid")
+         + [0x04] + [len(b"foo")] + l(b"foo"),
          ),
 
         (pureldap.LDAPFilter_and,
@@ -136,11 +136,11 @@ class KnownValues(unittest.TestCase):
          pureldap.LDAPBERDecoderContext_Filter(fallback=pureber.BERDecoderContext()),
          [0xa0, 23]
          + [0xa3, 9]
-         + [0x04] + [len("cn")] + l("cn")
-         + [0x04] + [len("foo")] + l("foo")
+         + [0x04] + [len(b"cn")] + l(b"cn")
+         + [0x04] + [len(b"foo")] + l(b"foo")
          + [0xa3, 10]
-         + [0x04] + [len("uid")] + l("uid")
-         + [0x04] + [len("foo")] + l("foo"),
+         + [0x04] + [len(b"uid")] + l(b"uid")
+         + [0x04] + [len(b"foo")] + l(b"foo"),
          ),
 
         (pureldap.LDAPModifyDNRequest,
@@ -152,11 +152,11 @@ class KnownValues(unittest.TestCase):
          None,
          [0x6c, 0x26]
          + [0x04]
-         + [len("cn=foo,dc=example,dc=com")]
-         + l("cn=foo,dc=example,dc=com")
+         + [len(b"cn=foo,dc=example,dc=com")]
+         + l(b"cn=foo,dc=example,dc=com")
          + [0x04]
-         + [len("uid=bar")]
-         + l("uid=bar")
+         + [len(b"uid=bar")]
+         + l(b"uid=bar")
          + [0x01, 0x01, 0x00]),
 
         (pureldap.LDAPModifyDNRequest,
@@ -169,15 +169,15 @@ class KnownValues(unittest.TestCase):
          None,
          [0x6c, 69]
          + [0x04]
-         + [len("cn=aoue,dc=example,dc=com")]
-         + l("cn=aoue,dc=example,dc=com")
+         + [len(b"cn=aoue,dc=example,dc=com")]
+         + l(b"cn=aoue,dc=example,dc=com")
          + [0x04]
-         + [len("uid=aoue")]
-         + l("uid=aoue")
+         + [len(b"uid=aoue")]
+         + l(b"uid=aoue")
          + [0x01, 0x01, 0x00]
          + [0x80]
-         + [len("ou=People,dc=example,dc=com")]
-         + l("ou=People,dc=example,dc=com")),
+         + [len(b"ou=People,dc=example,dc=com")]
+         + l(b"ou=People,dc=example,dc=com")),
 
         (pureldap.LDAPSearchRequest,
          [],
@@ -186,8 +186,8 @@ class KnownValues(unittest.TestCase):
          None,
          [0x63, 57]
          + [0x04]
-         + [len('dc=yoja,dc=example,dc=com')]
-         + l('dc=yoja,dc=example,dc=com')
+         + [len(b'dc=yoja,dc=example,dc=com')]
+         + l(b'dc=yoja,dc=example,dc=com')
          # scope
          + [0x0a, 1, 2]
          # derefAliases
@@ -199,7 +199,7 @@ class KnownValues(unittest.TestCase):
          # typesOnly
          + [0x01, 1, 0]
          # filter
-         + [135, 11] + l('objectClass')
+         + [135, 11] + l(b'objectClass')
          # attributes
          + [48, 0]
          ),
@@ -221,12 +221,12 @@ class KnownValues(unittest.TestCase):
          + [0x0a, 0x01, 0x00]
          # matchedDN
          + [0x04]
-         + [len('')]
-         + l('')
+         + [len(b'')]
+         + l(b'')
          # errorMessage
          + [0x04]
-         + [len('')]
-         + l('')
+         + [len(b'')]
+         + l(b'')
          # referral, TODO
          + []
         ),
@@ -242,12 +242,12 @@ class KnownValues(unittest.TestCase):
          + [0x0a, 0x01, 0x00]
          # matchedDN
          + [0x04]
-         + [len('dc=foo,dc=example,dc=com')]
-         + l('dc=foo,dc=example,dc=com')
+         + [len(b'dc=foo,dc=example,dc=com')]
+         + l(b'dc=foo,dc=example,dc=com')
          # errorMessage
          + [0x04]
-         + [len('')]
-         + l('')
+         + [len(b'')]
+         + l(b'')
          # referral, TODO
          + []
         ),
@@ -264,12 +264,12 @@ class KnownValues(unittest.TestCase):
          + [0x0a, 0x01, 0x00]
          # matchedDN
          + [0x04]
-         + [len('dc=foo,dc=example,dc=com')]
-         + l('dc=foo,dc=example,dc=com')
+         + [len(b'dc=foo,dc=example,dc=com')]
+         + l(b'dc=foo,dc=example,dc=com')
          # errorMessage
          + [0x04]
-         + [len('the foobar was fubar')]
-         + l('the foobar was fubar',)
+         + [len(b'the foobar was fubar')]
+         + l(b'the foobar was fubar',)
          # referral, TODO
          + []
         ),
@@ -285,12 +285,12 @@ class KnownValues(unittest.TestCase):
          + [0x0a, 0x01, 0x00]
          # matchedDN
          + [0x04]
-         + [len('')]
-         + l('')
+         + [len(b'')]
+         + l(b'')
          # errorMessage
          + [0x04]
-         + [len('the foobar was fubar')]
-         + l('the foobar was fubar',)
+         + [len(b'the foobar was fubar')]
+         + l(b'the foobar was fubar',)
          # referral, TODO
          + []
         ),
@@ -308,7 +308,7 @@ class KnownValues(unittest.TestCase):
          # id
          + [0x02, 0x01, 42]
          # value
-         + l(str(pureldap.LDAPBindRequest()))
+         + l(pureldap.LDAPBindRequest().toWire())
          ),
 
         (pureldap.LDAPControl,
@@ -319,7 +319,7 @@ class KnownValues(unittest.TestCase):
          [0x30, 9]
          # controlType
          + [0x04, 7]
-         + l("1.2.3.4")
+         + l(b"1.2.3.4")
          ),
 
         (pureldap.LDAPControl,
@@ -331,7 +331,7 @@ class KnownValues(unittest.TestCase):
          [0x30, 12]
          # controlType
          + [0x04, 7]
-         + l("1.2.3.4")
+         + l(b"1.2.3.4")
          # criticality
          + [0x01, 1, 0xFF]
          ),
@@ -346,12 +346,12 @@ class KnownValues(unittest.TestCase):
          [0x30, 19]
          # controlType
          + [0x04, 7]
-         + l("1.2.3.4")
+         + l(b"1.2.3.4")
          # criticality
          + [0x01, 1, 0xFF]
          # controlValue
-         + [0x04, len("silly")]
-         + l("silly")
+         + [0x04, len(b"silly")]
+         + l(b"silly")
          ),
 
         (pureldap.LDAPMessage,
@@ -360,8 +360,8 @@ class KnownValues(unittest.TestCase):
           'value': pureldap.LDAPBindRequest(),
           'controls': [ ('1.2.3.4', None, None),
                         ('2.3.4.5', False),
-                        ('3.4.5.6', True, '\x00\x01\x02\xFF'),
-                        ('4.5.6.7', None, '\x00\x01\x02\xFF'),
+                        ('3.4.5.6', True, b'\x00\x01\x02\xFF'),
+                        ('4.5.6.7', None, b'\x00\x01\x02\xFF'),
                         ],
           },
          pureldap.LDAPBERDecoderContext_TopLevel(
@@ -372,19 +372,19 @@ class KnownValues(unittest.TestCase):
          # id
          + [0x02, 0x01, 42]
          # value
-         + l(str(pureldap.LDAPBindRequest()))
+         + l(pureldap.LDAPBindRequest().toWire())
          # controls
-         + l(str(pureldap.LDAPControls(value=[
+         + l(pureldap.LDAPControls(value=[
         pureldap.LDAPControl(controlType='1.2.3.4'),
         pureldap.LDAPControl(controlType='2.3.4.5',
                              criticality=False),
         pureldap.LDAPControl(controlType='3.4.5.6',
                              criticality=True,
-                             controlValue='\x00\x01\x02\xFF'),
+                             controlValue=b'\x00\x01\x02\xFF'),
         pureldap.LDAPControl(controlType='4.5.6.7',
                              criticality=None,
-                             controlValue='\x00\x01\x02\xFF'),
-        ]))),
+                             controlValue=b'\x00\x01\x02\xFF'),
+        ]).toWire()),
          ),
 
         (pureldap.LDAPFilter_equalityMatch,
@@ -397,8 +397,8 @@ class KnownValues(unittest.TestCase):
         inherit=pureldap.LDAPBERDecoderContext(fallback=pureber.BERDecoderContext())),
 
          [0xa3, 9]
-         + ([0x04, 2] + l('cn')
-            + [0x04, 3] + l('foo'))
+         + ([0x04, 2] + l(b'cn')
+            + [0x04, 3] + l(b'foo'))
          ),
 
         (pureldap.LDAPFilter_or,
@@ -417,18 +417,18 @@ class KnownValues(unittest.TestCase):
 
          [0xA1, 52]
          + ([0xa3, 9]
-            + ([0x04, 2] + l('cn')
-               + [0x04, 3] + l('foo'))
+            + ([0x04, 2] + l(b'cn')
+               + [0x04, 3] + l(b'foo'))
             + [0xa3, 10]
-            + ([0x04, 3] + l('uid')
-               + [0x04, 3] + l('foo'))
+            + ([0x04, 3] + l(b'uid')
+               + [0x04, 3] + l(b'foo'))
             + [0xa3, 11]
-               + ([0x04, 4] + l('mail')
-                  + [0x04, 3] + l('foo'))
+               + ([0x04, 4] + l(b'mail')
+                  + [0x04, 3] + l(b'foo'))
             + [0xa4, 14]
-            + ([0x04, 4] + l('mail')
+            + ([0x04, 4] + l(b'mail')
                + [0x30, 6]
-               + ([0x80, 4] + l('foo@'))))
+               + ([0x80, 4] + l(b'foo@'))))
          ),
 
         (pureldap.LDAPSearchRequest,
@@ -455,7 +455,7 @@ class KnownValues(unittest.TestCase):
         inherit=pureldap.LDAPBERDecoderContext(fallback=pureber.BERDecoderContext())),
 
          [0x63, 92]
-         + ([0x04, 17] + l('dc=example,dc=com')
+         + ([0x04, 17] + l(b'dc=example,dc=com')
             + [0x0a, 1, 0x02]
             + [0x0a, 1, 0x00]
             + [0x02, 1, 0x01]
@@ -463,18 +463,18 @@ class KnownValues(unittest.TestCase):
             + [0x01, 1, 0x00]
             + [0xA1, 52]
             + ([0xa3, 9]
-               + ([0x04, 2] + l('cn')
-                  + [0x04, 3] + l('foo'))
+               + ([0x04, 2] + l(b'cn')
+                  + [0x04, 3] + l(b'foo'))
                + [0xa3, 10]
-               + ([0x04, 3] + l('uid')
-                  + [0x04, 3] + l('foo'))
+               + ([0x04, 3] + l(b'uid')
+                  + [0x04, 3] + l(b'foo'))
                + [0xa3, 11]
-               + ([0x04, 4] + l('mail')
-                  + [0x04, 3] + l('foo'))
+               + ([0x04, 4] + l(b'mail')
+                  + [0x04, 3] + l(b'foo'))
                + [0xa4, 14]
-               + ([0x04, 4] + l('mail')
+               + ([0x04, 4] + l(b'mail')
                   + [0x30, 6]
-                  + ([0x80, 4] + l('foo@'))))
+                  + ([0x80, 4] + l(b'foo@'))))
             + [0x30, 2]
             + ([0x04, 0])
             )
@@ -512,7 +512,7 @@ class KnownValues(unittest.TestCase):
          + [0x02, 1, 1]
          # value
          + [0x63, 92]
-         + ([0x04, 17] + l('dc=example,dc=com')
+         + ([0x04, 17] + l(b'dc=example,dc=com')
             + [0x0a, 1, 0x02]
             + [0x0a, 1, 0x00]
             + [0x02, 1, 0x01]
@@ -520,18 +520,18 @@ class KnownValues(unittest.TestCase):
             + [0x01, 1, 0x00]
             + [0xA1, 52]
             + ([0xa3, 9]
-               + ([0x04, 2] + l('cn')
-                  + [0x04, 3] + l('foo'))
+               + ([0x04, 2] + l(b'cn')
+                  + [0x04, 3] + l(b'foo'))
                + [0xa3, 10]
-               + ([0x04, 3] + l('uid')
-                  + [0x04, 3] + l('foo'))
+               + ([0x04, 3] + l(b'uid')
+                  + [0x04, 3] + l(b'foo'))
                + [0xa3, 11]
-               + ([0x04, 4] + l('mail')
-                  + [0x04, 3] + l('foo'))
+               + ([0x04, 4] + l(b'mail')
+                  + [0x04, 3] + l(b'foo'))
                + [0xa4, 14]
-               + ([0x04, 4] + l('mail')
+               + ([0x04, 4] + l(b'mail')
                   + [0x30, 6]
-                  + ([0x80, 4] + l('foo@'))))
+                  + ([0x80, 4] + l(b'foo@'))))
             + [0x30, 2]
             + ([0x04, 0])
             )
@@ -545,11 +545,11 @@ class KnownValues(unittest.TestCase):
          None,
          [0x40|0x20|23, 1+1+8+1+1+3]
          + ([0x80|0]
-            + [len('42.42.42')]
-            + l('42.42.42'))
+            + [len(b'42.42.42')]
+            + l(b'42.42.42'))
          + ([0x80|1]
-            + [len('foo')]
-            + l('foo'))
+            + [len(b'foo')]
+            + l(b'foo'))
          ),
 
         (pureldap.LDAPExtendedRequest,
@@ -560,8 +560,8 @@ class KnownValues(unittest.TestCase):
          None,
          [0x40|0x20|23, 1+1+8]
          + ([0x80|0]
-            + [len('42.42.42')]
-            + l('42.42.42'))
+            + [len(b'42.42.42')]
+            + l(b'42.42.42'))
          ),
 
         (pureldap.LDAPExtendedResponse,
@@ -575,8 +575,8 @@ class KnownValues(unittest.TestCase):
          None,
          [0x40|0x20|24, 3+2+3+2+3,
           0x0a, 1, 49,
-          0x04, len('foo')] + l('foo') + [
-          0x04, len('bar')] + l('bar'),
+          0x04, len(b'foo')] + l(b'foo') + [
+          0x04, len(b'bar')] + l(b'bar'),
          ),
 
         (pureldap.LDAPExtendedResponse,
@@ -590,10 +590,10 @@ class KnownValues(unittest.TestCase):
          None,
          [0x40|0x20|24, 3+2+3+2+3+2+len('1.2.3.4.5.6.7.8.9')+2+3,
           0x0a, 1, 49,
-          0x04, len('foo')] + l('foo') + [
-          0x04, len('bar')] + l('bar') + [
-          0x8a, len('1.2.3.4.5.6.7.8.9')] + l('1.2.3.4.5.6.7.8.9') + [
-          0x8b, len('baz')] + l('baz'),
+          0x04, len(b'foo')] + l(b'foo') + [
+          0x04, len(b'bar')] + l(b'bar') + [
+          0x8a, len(b'1.2.3.4.5.6.7.8.9')] + l(b'1.2.3.4.5.6.7.8.9') + [
+          0x8b, len(b'baz')] + l(b'baz'),
          ),
 
         (pureldap.LDAPAbandonRequest,
@@ -610,16 +610,16 @@ class KnownValues(unittest.TestCase):
          pureldap.LDAPBERDecoderContext(
                 fallback=pureldap.LDAPBERDecoderContext(fallback=pureber.BERDecoderContext()),
                 inherit=pureldap.LDAPBERDecoderContext(fallback=pureber.BERDecoderContext())),
-         [ord(x) for x in str(pureldap.LDAPBindRequest(auth=('PLAIN', 'test'), sasl=True))]
+         l(pureldap.LDAPBindRequest(auth=('PLAIN', 'test'), sasl=True).toWire())
          )
         )
 
     def testToLDAP(self):
-        """str(LDAPClass(...)) should give known result with known input"""
+        """LDAPClass(...).toWire() should give known result with known input"""
         for klass, args, kwargs, decoder, encoded in self.knownValues:
             result = klass(*args, **kwargs)
-            result = str(result)
-            result = [ord(x) for x in result]
+            result = result.toWire()
+            result = l(result)
 
             message = (
                 "Class %s(*%r, **%r) doesn't encode properly: "
@@ -638,8 +638,7 @@ class KnownValues(unittest.TestCase):
             self.assertEqual(bytes, len(m))
 
             shouldBe = klass(*args, **kwargs)
-            #TODO shouldn't use str below
-            assert str(result)==str(shouldBe), \
+            assert result.toWire() == shouldBe.toWire(), \
                    "Class %s(*%s, **%s) doesn't decode properly: " \
                    "%s != %s" % (klass.__name__,
                                  repr(args), repr(kwargs),
@@ -697,9 +696,9 @@ class Substrings(unittest.TestCase):
             fallback=pureber.BERDecoderContext())
         filt = pureldap.LDAPFilter_substrings.fromBER(
             tag=pureldap.LDAPFilter_substrings.tag,
-            content=s(0x04, 4, 'mail',
+            content=s(0x04, 4, b'mail',
                       0x30, 6,
-                      0x80, 4, 'foo@'),
+                      0x80, 4, b'foo@'),
             berdecoder=decoder)
         # The confusion that used to occur here was because
         # filt.substrings was left as a BERSequence, which under the

--- a/ldaptor/testutil.py
+++ b/ldaptor/testutil.py
@@ -5,6 +5,7 @@ from twisted.python import failure
 from twisted.trial import unittest
 from twisted.test import proto_helpers
 from ldaptor import config
+from ldaptor.encoder import to_bytes
 
 
 def mustRaise(dummy):
@@ -127,8 +128,8 @@ class LDAPClientTestDriver:
             shouldBeSent,
             self.sent)
         assert self.sent == shouldBeSent, msg
-        sentStr = ''.join([str(x) for x in self.sent])
-        shouldBeSentStr = ''.join([str(x) for x in shouldBeSent])
+        sentStr = b''.join([to_bytes(x) for x in self.sent])
+        shouldBeSentStr = b''.join([to_bytes(x) for x in shouldBeSent])
         msg = '%s expected to send data %r but sent %r' % (
             self.__class__.__name__,
             shouldBeSentStr,

--- a/tox.ini
+++ b/tox.ini
@@ -52,7 +52,7 @@ commands =
 
     test: coverage run --rcfile={toxinidir}/.coveragerc -m twisted.trial {posargs:ldaptor}
 
-    ported: trial ldaptor.test.test_attributeset ldaptor.test.test_autofill ldaptor.test.test_autofill_posix ldaptor.test.test_autofill_samba ldaptor.test.test_config ldaptor.test.test_connector ldaptor.test.test_delta ldaptor.test.test_dns ldaptor.test.test_entry ldaptor.test.test_fetchschema ldaptor.test.test_match ldaptor.test.test_schema ldaptor.test.test_usage ldaptor.test.test_ldapfilter ldaptor.test.test_smbpassword ldaptor.test.test_ldapsyntax ldaptor.test.test_pureber
+    ported: trial ldaptor.test.test_attributeset ldaptor.test.test_autofill ldaptor.test.test_autofill_posix ldaptor.test.test_autofill_samba ldaptor.test.test_config ldaptor.test.test_connector ldaptor.test.test_delta ldaptor.test.test_dns ldaptor.test.test_entry ldaptor.test.test_fetchschema ldaptor.test.test_match ldaptor.test.test_schema ldaptor.test.test_usage ldaptor.test.test_ldapfilter ldaptor.test.test_smbpassword ldaptor.test.test_ldapsyntax ldaptor.test.test_pureber ldaptor.test.test_pureldap
 
     ; Only run on local dev env.
     dev: coverage report --show-missing


### PR DESCRIPTION
This pull request includes the changes from the master branch:

* Support asText for LDAPFilter_extensibleMatch, add escaper to LDAPMatchingRuleAssertion
* pureber and pureldap classes switching to toWire method for getting their bytes representation